### PR TITLE
fix: wrap long code blocks in statement output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cnoi-statement-generator",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cnoi-statement-generator",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "AGPL-3.0",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",

--- a/src/compiler/remarkTypst/compiler.ts
+++ b/src/compiler/remarkTypst/compiler.ts
@@ -37,6 +37,10 @@ export interface AssetInfo {
   filename: string;
 }
 
+export interface CompilerOptions {
+  codeSoftBreakInterval?: number;
+}
+
 export interface CompilerContext {
   assets: AssetInfo[];
   data: string[];
@@ -45,6 +49,7 @@ export interface CompilerContext {
     string,
     { node: mdast.FootnoteDefinition; visited: boolean }
   >;
+  options: CompilerOptions;
 }
 
 const FOOTNOTE_ID_PREFIX = "user-footnote: ";
@@ -62,25 +67,29 @@ export function escapeTypstString(s: string) {
 }
 
 const CODE_SOFT_BREAK = "\u{200b}";
-const CODE_SOFT_BREAK_INTERVAL = 56;
-const LONG_CODE_RUN_REGEX = /\S{57,}/g;
-const CODE_SOFT_BREAK_CHUNK_REGEX = new RegExp(
-  `(.{${CODE_SOFT_BREAK_INTERVAL}})(?=.)`,
-  "g",
-);
+function insertBreaksIntoCodeRun(run: string, interval: number) {
+  const chars = Array.from(run);
+  const chunks: string[] = [];
+  for (let i = 0; i < chars.length; i += interval)
+    chunks.push(chars.slice(i, i + interval).join(""));
+  return chunks.join(CODE_SOFT_BREAK);
+}
 
-export function insertCodeSoftBreaks(s: string) {
-  return s.replace(LONG_CODE_RUN_REGEX, (run) =>
-    run.replace(CODE_SOFT_BREAK_CHUNK_REGEX, `$1${CODE_SOFT_BREAK}`),
+export function insertCodeSoftBreaks(s: string, interval: number) {
+  if (!Number.isSafeInteger(interval) || interval <= 0) return s;
+  const longCodeRunRegex = new RegExp(`\\S{${interval + 1},}`, "gu");
+  return s.replace(longCodeRunRegex, (run) =>
+    insertBreaksIntoCodeRun(run, interval),
   );
 }
 
-export function initContext(): CompilerContext {
+export function initContext(options: CompilerOptions = {}): CompilerContext {
   return {
     assets: [],
     data: [],
     definitionById: new Map(),
     footnoteById: new Map(),
+    options,
   };
 }
 
@@ -178,7 +187,11 @@ export const handlers = {
     data.push("]\n");
   },
   code: (node, ctx) => {
-    const { data } = ctx;
+    const { data, options } = ctx;
+    const value =
+      options.codeSoftBreakInterval === undefined
+        ? node.value
+        : insertCodeSoftBreaks(node.value, options.codeSoftBreakInterval);
     data.push(
       `#raw(block: true, lang: "${escapeTypstString(
         !node.lang
@@ -189,7 +202,7 @@ export const handlers = {
               ? "md"
               : node.lang,
       )}", "`,
-      escapeTypstString(insertCodeSoftBreaks(node.value)),
+      escapeTypstString(value),
       '")\n',
     );
   },
@@ -426,8 +439,11 @@ function parseRoot(node: mdast.Root, ctx: CompilerContext) {
   data.push("]))\n");
 }
 
-export default function compileMdast(tree: mdast.Root): [string, AssetInfo[]] {
-  const ctx = initContext();
+export default function compileMdast(
+  tree: mdast.Root,
+  options?: CompilerOptions,
+): [string, AssetInfo[]] {
+  const ctx = initContext(options);
   collectDefinitions(tree, ctx);
   parseRoot(tree, ctx);
   return [ctx.data.join(""), ctx.assets];

--- a/src/compiler/remarkTypst/compiler.ts
+++ b/src/compiler/remarkTypst/compiler.ts
@@ -61,6 +61,20 @@ export function escapeTypstString(s: string) {
     .replace(/\r/g, "\\r");
 }
 
+const CODE_SOFT_BREAK = "\u{200b}";
+const CODE_SOFT_BREAK_INTERVAL = 56;
+const LONG_CODE_RUN_REGEX = /\S{57,}/g;
+const CODE_SOFT_BREAK_CHUNK_REGEX = new RegExp(
+  `(.{${CODE_SOFT_BREAK_INTERVAL}})(?=.)`,
+  "g",
+);
+
+export function insertCodeSoftBreaks(s: string) {
+  return s.replace(LONG_CODE_RUN_REGEX, (run) =>
+    run.replace(CODE_SOFT_BREAK_CHUNK_REGEX, `$1${CODE_SOFT_BREAK}`),
+  );
+}
+
 export function initContext(): CompilerContext {
   return {
     assets: [],
@@ -175,7 +189,7 @@ export const handlers = {
               ? "md"
               : node.lang,
       )}", "`,
-      escapeTypstString(node.value),
+      escapeTypstString(insertCodeSoftBreaks(node.value)),
       '")\n',
     );
   },

--- a/src/compiler/remarkTypst/index.ts
+++ b/src/compiler/remarkTypst/index.ts
@@ -11,6 +11,10 @@ declare module "vfile" {
      * Assets collected during compilation.
      */
     assets: Array<AssetInfo>;
+    /**
+     * Optional maximum raw-code run length before invisible soft break points are inserted.
+     */
+    typstCodeSoftBreakInterval?: number;
   }
 }
 
@@ -18,7 +22,9 @@ const remarkTypst: Plugin<[], mdast.Root, string> = function () {
   this.compiler = (tree, file) => {
     if (tree.type !== "root")
       throw new TypeError(`Expected root node, got ${tree.type}`);
-    const [res, assets] = compileMdast(tree as mdast.Root);
+    const [res, assets] = compileMdast(tree as mdast.Root, {
+      codeSoftBreakInterval: file.data.typstCodeSoftBreakInterval,
+    });
     file.data.assets = assets;
     return res;
   };

--- a/src/router/root/index.tsx
+++ b/src/router/root/index.tsx
@@ -177,6 +177,7 @@ const RootImpl: FC<{
 const ChangeLog = () => {
   return (
     <div className="root-changelog">
+      <p>加 QQ 群（1012989587）关注项目最新动态。也可反馈问题或闲聊。</p>
       <h1>更新日志</h1>
       <article dangerouslySetInnerHTML={{ __html: changeLogHTML }} />
     </div>

--- a/templates/cnoi/typst/main.typ
+++ b/templates/cnoi/typst/main.typ
@@ -132,6 +132,17 @@
 }
 
 #let in-raw = state("in-raw", false)
+#let raw-line-body(body) = {
+  // Preserve raw spacing while allowing Typst to wrap long code lines at spaces.
+  show regex(" "): s => s + sym.zws
+  par(
+    leading: 0.62em,
+    spacing: 0pt,
+    first-line-indent: 0pt,
+    hanging-indent: 4em,
+    body,
+  )
+}
 #show strong: st => {
   if in-raw.get() { st } else {
     set text(font: ("Latin Modern Roman 12", "SimHei"))
@@ -195,13 +206,13 @@
             box(
               grid(
                 columns: (0pt, 0pt, 100% - 6pt),
-                align: (bottom, bottom, bottom),
+                align: (top, top, top),
                 move(
                   dx: -9pt - measure([#jt.number]).width,
                   text(fill: rgb("#808080"), size: 10pt, [#jt.number]),
                 ),
                 cjk-align-mark,
-                jt.body,
+                raw-line-body(jt.body),
               ),
             ),
             stroke: stroke,

--- a/templates/cnoi/unifiedPlugins.ts
+++ b/templates/cnoi/unifiedPlugins.ts
@@ -1,7 +1,9 @@
 import type mdast from "mdast";
+import type { VFile } from "vfile";
 
 export default [
-  () => (tree: mdast.Root) => {
+  () => (tree: mdast.Root, file: VFile) => {
+    file.data.typstCodeSoftBreakInterval = 56;
     tree.children.unshift({
       type: "typst",
       children: [{ type: "typstContent", data: `#import "header.typ": *\n\n` }],

--- a/tests/unit/remark-typst.common.test.ts
+++ b/tests/unit/remark-typst.common.test.ts
@@ -4,6 +4,7 @@ import compileMdast, {
   collectDefinitions,
   escapeTypstString,
   handlers,
+  insertCodeSoftBreaks,
   TYPST_RELATIVE_VALUE_REGEX,
 } from "@/compiler/remarkTypst/compiler";
 import { h64 } from "xxhashjs";
@@ -157,6 +158,20 @@ test("Escape Typst String", () => {
     'This is a \\"test\\" string with \\\\ backslash,\\nnew line,\\ttab, and \\rcarriage return.' +
       '\\"These\\" \\\\ backslash,\\nnew line,\\ttab, and \\rcarriage appears again.',
   );
+});
+
+describe("Code Soft Breaks", () => {
+  test("keeps short code runs unchanged", () => {
+    const code = "std::vector<int> value";
+    expect(insertCodeSoftBreaks(code)).toBe(code);
+  });
+
+  test("adds invisible break points to long code runs", () => {
+    const code = `cout<<"${"a".repeat(120)}";`;
+    const result = insertCodeSoftBreaks(code);
+    expect(result).toContain("\u{200b}");
+    expect(result.replaceAll("\u{200b}", "")).toBe(code);
+  });
 });
 
 describe("Handlers", () => {

--- a/tests/unit/remark-typst.common.test.ts
+++ b/tests/unit/remark-typst.common.test.ts
@@ -163,13 +163,20 @@ test("Escape Typst String", () => {
 describe("Code Soft Breaks", () => {
   test("keeps short code runs unchanged", () => {
     const code = "std::vector<int> value";
-    expect(insertCodeSoftBreaks(code)).toBe(code);
+    expect(insertCodeSoftBreaks(code, 56)).toBe(code);
   });
 
   test("adds invisible break points to long code runs", () => {
     const code = `cout<<"${"a".repeat(120)}";`;
-    const result = insertCodeSoftBreaks(code);
+    const result = insertCodeSoftBreaks(code, 56);
     expect(result).toContain("\u{200b}");
+    expect(result.replaceAll("\u{200b}", "")).toBe(code);
+  });
+
+  test("does not split surrogate pairs", () => {
+    const code = "a".repeat(55) + "😀" + "b".repeat(10);
+    const result = insertCodeSoftBreaks(code, 56);
+    expect(result).toContain("😀");
     expect(result.replaceAll("\u{200b}", "")).toBe(code);
   });
 });
@@ -365,6 +372,22 @@ describe("Handlers", () => {
       );
       expect(ctx.data.join("")).toBe(
         '#raw(block: true, lang: "md", "# This is a markdown code block\\nSome *emphasis* here.\\n")\n',
+      );
+    });
+    test("Soft Breaks are Opt-in", () => {
+      const code = `cout<<"${"a".repeat(120)}";`;
+      const ctx = initContext();
+      handlers.code({ type: "code", lang: "cpp", value: code }, ctx);
+      expect(ctx.data.join("")).not.toContain("\u{200b}");
+    });
+    test("Configured Soft Breaks are emitted in Block Code", () => {
+      const code = `cout<<"${"a".repeat(120)}";`;
+      const ctx = initContext({ codeSoftBreakInterval: 56 });
+      handlers.code({ type: "code", lang: "cpp", value: code }, ctx);
+      const text = ctx.data.join("");
+      expect(text).toContain("\u{200b}");
+      expect(text.replaceAll("\u{200b}", "")).toContain(
+        escapeTypstString(code),
       );
     });
   });


### PR DESCRIPTION
Fixes #117

### Test
Before:
<img width="1683" height="241" alt="image" src="https://github.com/user-attachments/assets/c1857555-0791-4aa4-abba-ecdbb185932b" />
After:
<img width="1484" height="348" alt="image" src="https://github.com/user-attachments/assets/b0d9079a-1ecc-4922-9414-cca6538f30f8" />
